### PR TITLE
Fix Movistar picture listings and Windows WebDAV writes

### DIFF
--- a/src/o2gateway/o2/movistar.py
+++ b/src/o2gateway/o2/movistar.py
@@ -38,11 +38,34 @@ class MovistarCloudApiClient(O2CloudApiClient):
             for item in details:
                 if item.id in seen:
                     continue
-                seen.add(item.id)
                 if item.parent_id and _o2_id(item.parent_id) != _o2_id(folder_id):
                     continue
+                seen.add(item.id)
                 output.append(item)
             if not data.get("more") or len(media) < PAGE_SIZE:
+                break
+
+        for offset in range(0, 100000, PAGE_SIZE):
+            payload = await self._json(
+                "POST",
+                "media/picture",
+                {
+                    "action": "get",
+                    "folderid": folder_id,
+                    "limit": str(PAGE_SIZE),
+                    "offset": str(offset),
+                },
+                {"data": {"fields": []}},
+            )
+            pictures = self._items_from_payload(payload, ("pictures", "media", "images", "items"))
+            for item in pictures:
+                if item.id in seen:
+                    continue
+                if item.parent_id and _o2_id(item.parent_id) != _o2_id(folder_id):
+                    continue
+                seen.add(item.id)
+                output.append(item)
+            if len(pictures) < PAGE_SIZE:
                 break
         return output
 
@@ -71,9 +94,12 @@ class MovistarCloudApiClient(O2CloudApiClient):
 
     async def _file_details(self, ids: list[str]) -> list[O2Item]:
         payload = await self._json("POST", "media/file", {"action": "get"}, {"data": {"ids": [_o2_id(item_id) for item_id in ids]}})
+        return self._items_from_payload(payload, ("files", "media", "items"))
+
+    def _items_from_payload(self, payload: dict[str, Any], array_names: tuple[str, ...]) -> list[O2Item]:
         data = _object(payload.get("data"))
         media_server = _first_media_string(data, "mediaserverurl") or self.settings.o2_api_base_url.split("/sapi")[0]
-        files = _first_array(data, "files", "media", "items") or _first_array(payload, "files", "media", "items")
+        files = _first_array(data, *array_names) or _first_array(payload, *array_names)
         output: list[O2Item] = []
         for file_item in files:
             item_id = (_media_id_candidates(file_item) or [""])[0]

--- a/src/o2gateway/webdav/locks.py
+++ b/src/o2gateway/webdav/locks.py
@@ -39,6 +39,13 @@ class WebDavLockService:
         )
         return WebDavLock(token=token, path=normalized, owner=owner, expires_at=expires_at)
 
+    async def release_path(self, path: str) -> None:
+        await self.cleanup()
+        await self.db.execute(
+            "delete from locks where path = ?",
+            (normalize_cloud_path(path),),
+        )
+
     async def release(self, token: str) -> bool:
         await self.cleanup()
         before = await self.db.fetchone("select token from locks where token = ?", (token,))
@@ -72,4 +79,3 @@ class WebDavLockService:
             (time.time(),),
         )
         return [WebDavLock(token=row["token"], path=row["path"], owner=row["owner"] or "", expires_at=row["expires_at"]) for row in rows]
-

--- a/src/o2gateway/webdav/router.py
+++ b/src/o2gateway/webdav/router.py
@@ -77,7 +77,9 @@ def create_webdav_router(
                 if _is_ignored_appledouble(settings, cloud_path):
                     return Response(status_code=204)
                 await locks.assert_can_write(cloud_path, request.headers.get("if"))
-                return await _delete(store, cloud_path)
+                response = await _delete(store, cloud_path)
+                await locks.release_path(cloud_path)
+                return response
             if method == "MOVE":
                 _assert_writable(settings)
                 await locks.assert_can_write(cloud_path, request.headers.get("if"))
@@ -92,7 +94,7 @@ def create_webdav_router(
             if method == "UNLOCK":
                 return await _unlock(locks, request)
             if method == "PROPPATCH":
-                return Response(status_code=405)
+                return await _proppatch(request)
             return Response(status_code=405)
         except CloudNotFound as ex:
             logger.debug("webdav not found", extra={"operationId": operation_id, "path": str(ex)})
@@ -131,6 +133,14 @@ def _options() -> Response:
             "MS-Author-Via": "DAV",
         },
     )
+
+
+async def _proppatch(request: Request) -> Response:
+    try:
+        payload = xml.proppatch_multistatus(request.url.path, await request.body())
+    except xml.etree.XMLSyntaxError as ex:
+        raise ValueError("invalid PROPPATCH XML") from ex
+    return Response(payload, status_code=207, media_type="application/xml")
 
 
 async def _propfind(settings: Settings, store: CloudFileStore, cloud_path: str, request: Request) -> Response:

--- a/src/o2gateway/webdav/xml.py
+++ b/src/o2gateway/webdav/xml.py
@@ -60,6 +60,19 @@ def lockdiscovery(lock: WebDavLock) -> bytes:
     return etree.tostring(root, xml_declaration=True, encoding="utf-8")
 
 
+def proppatch_multistatus(href: str, request_body: bytes) -> bytes:
+    requested = etree.fromstring(request_body)
+    root = etree.Element("{%s}multistatus" % DAV, nsmap=NSMAP)
+    response = etree.SubElement(root, "{%s}response" % DAV)
+    etree.SubElement(response, "{%s}href" % DAV).text = href
+    propstat = etree.SubElement(response, "{%s}propstat" % DAV)
+    response_props = etree.SubElement(propstat, "{%s}prop" % DAV)
+    for prop in requested.xpath("//*[local-name()='prop']/*"):
+        etree.SubElement(response_props, prop.tag)
+    etree.SubElement(propstat, "{%s}status" % DAV).text = "HTTP/1.1 200 OK"
+    return etree.tostring(root, xml_declaration=True, encoding="utf-8")
+
+
 def error_response(message: str) -> bytes:
     root = etree.Element("{%s}error" % DAV, nsmap=NSMAP)
     etree.SubElement(root, "{%s}responsedescription" % DAV).text = message
@@ -76,4 +89,3 @@ def http_date(value: Optional[datetime]) -> str:
     if value is None:
         value = datetime.now(timezone.utc)
     return format_datetime(value.astimezone(timezone.utc), usegmt=True)
-

--- a/tests/test_movistar.py
+++ b/tests/test_movistar.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from o2gateway.o2.movistar import MovistarCloudApiClient
+
+
+class FakeMovistarClient(MovistarCloudApiClient):
+    def __init__(self) -> None:
+        self.settings = SimpleNamespace(o2_api_base_url="https://micloud.movistar.es/sapi/")
+        self.pictures = [
+            {
+                "id": "picture-%03d" % index,
+                "name": "photo-%03d.JPG" % index,
+                "folder": 10,
+                "size": 1024 + index,
+                "url": "/download/picture-%03d" % index,
+                "mediatype": "picture",
+            }
+            for index in range(201)
+        ]
+        self.pictures.append(
+            {
+                "id": "other-folder",
+                "name": "elsewhere.JPG",
+                "folder": 11,
+                "size": 42,
+                "url": "/download/other-folder",
+                "mediatype": "picture",
+            }
+        )
+
+    async def _json(self, method, resource, query, body=None, form=False):
+        assert method == "POST"
+        if resource == "media":
+            return {"data": {"media": [{"id": "raw-1"}], "more": False}}
+        if resource == "media/file":
+            return {
+                "data": {
+                    "mediaserverurl": "https://micloud.movistar.es",
+                    "files": [
+                        {
+                            "id": "raw-1",
+                            "name": "photo-raw.ARW",
+                            "folder": 10,
+                            "size": 2048,
+                            "url": "/download/raw-1",
+                            "mediatype": "file",
+                        }
+                    ],
+                }
+            }
+        if resource == "media/picture":
+            offset = int(query["offset"])
+            limit = int(query["limit"])
+            return {
+                "data": {
+                    "mediaserverurl": "https://micloud.movistar.es",
+                    "pictures": self.pictures[offset : offset + limit],
+                }
+            }
+        raise AssertionError("unexpected resource %s" % resource)
+
+
+@pytest.mark.asyncio
+async def test_movistar_lists_paginated_pictures_alongside_generic_files():
+    client = FakeMovistarClient()
+
+    items = await client._load_files("10")
+
+    extensions = [Path(item.name).suffix.upper() for item in items]
+    assert extensions.count(".ARW") == 1
+    assert extensions.count(".JPG") == 201
+    assert all(item.parent_id == "10" for item in items)
+    assert all(item.id != "other-folder" for item in items)

--- a/tests/test_webdav_windows.py
+++ b/tests/test_webdav_windows.py
@@ -1,0 +1,39 @@
+import pytest
+
+from o2gateway.webdav import xml
+from o2gateway.webdav.locks import WebDavLockService
+
+
+class RecordingDatabase:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple]] = []
+
+    async def execute(self, query: str, args: tuple = ()) -> None:
+        self.executed.append((query, args))
+
+
+def test_windows_proppatch_multistatus_accepts_requested_properties():
+    body = b"""\
+<D:propertyupdate xmlns:D="DAV:" xmlns:Z="urn:schemas-microsoft-com:">
+  <D:set><D:prop><Z:Win32FileAttributes>00000020</Z:Win32FileAttributes></D:prop></D:set>
+</D:propertyupdate>
+"""
+
+    payload = xml.proppatch_multistatus("/dav/file.txt", body).decode("utf-8")
+
+    assert "Win32FileAttributes" in payload
+    assert "HTTP/1.1 200 OK" in payload
+    assert "/dav/file.txt" in payload
+
+
+@pytest.mark.asyncio
+async def test_release_path_removes_resource_lock():
+    database = RecordingDatabase()
+    locks = WebDavLockService(database)  # type: ignore[arg-type]
+
+    await locks.release_path("/file.txt")
+
+    assert database.executed[-1] == (
+        "delete from locks where path = ?",
+        ("/file.txt",),
+    )


### PR DESCRIPTION
## What changed

- paginate Movistar's separate `media/picture` collection and merge pictures with generic files
- convert picture payloads through the same metadata mapper used for file details
- accept Windows `PROPPATCH` metadata as a no-op `207 Multi-Status`
- release a resource lock after a successful `DELETE`
- add regression tests for paginated Movistar pictures, folder filtering, Windows properties, and path-based lock release

## Why

Movistar returns generic files such as RAW/ARW through `media`, while JPEG pictures live in `media/picture`. The specialized client only queried the generic collection, so the web UI showed JPGs that WebDAV omitted.

Windows WebClient writes an empty placeholder, locks it, uploads the content, and sends `PROPPATCH` for Win32 metadata. Returning `405` made Windows roll the upload back with `DELETE`; the surviving lock then rejected retries with `403 resource is locked`.

## Impact

Movistar folders now expose their JPEG pictures through WebDAV, including folders with more than one API page. Windows can complete its native WebDAV write sequence without deleting successful uploads or leaving stale locks.

## Validation

- `pytest tests/test_movistar.py tests/test_webdav_windows.py tests/test_paths.py tests/test_simulated_store.py tests/test_xml.py -q`
- 8 tests passed
- live Movistar account check returned 362 JPGs in the folder that previously returned none
- live Windows-compatible `PROPPATCH` returned 207 and the lock table remained empty
