### PR TITLE
Stream WebDAV uploads to the cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The gateway is a single FastAPI/ASGI application (served by Uvicorn) that:
 3. Translates WebDAV operations into O2/Movistar Cloud API calls, caching metadata in a
    local SQLite database to keep listings fast.
 4. Stores the selected provider's session (cookies + validation key) encrypted on disk.
+5. Streams uploads with a known `Content-Length` to O2/Movistar while writing the
+   recovery spool concurrently. Chunked uploads retain the file-backed fallback path.
 
 The container also runs a headless X server (`Xvfb`) + `fluxbox` + `x11vnc` +
 `websockify`/`noVNC` so the interactive Chromium login can be driven from your

--- a/src/o2gateway/cloud/base.py
+++ b/src/o2gateway/cloud/base.py
@@ -50,6 +50,17 @@ class CloudFileStore(Protocol):
     async def upload(self, path: str, local_tmp_path: str, *, overwrite: bool = True) -> CloudItemMetadata:
         ...
 
+    async def upload_stream(
+        self,
+        path: str,
+        chunks: AsyncIterator[bytes],
+        size: int,
+        local_tmp_path: str,
+        *,
+        overwrite: bool = True,
+    ) -> CloudItemMetadata:
+        ...
+
     async def move(self, source: str, destination: str, *, overwrite: bool = False) -> CloudItemMetadata:
         ...
 
@@ -93,4 +104,3 @@ def parent_path(path: str) -> str:
 def basename(path: str) -> str:
     normalized = normalize_cloud_path(path)
     return "" if normalized == "/" else PurePosixPath(normalized).name
-

--- a/src/o2gateway/cloud/simulated.py
+++ b/src/o2gateway/cloud/simulated.py
@@ -76,6 +76,26 @@ class SimulatedCloudFileStore:
             shutil.copyfile(local_tmp_path, dest)
             return self._metadata(dest)
 
+    async def upload_stream(
+        self,
+        path: str,
+        chunks: AsyncIterator[bytes],
+        size: int,
+        local_tmp_path: str,
+        *,
+        overwrite: bool = True,
+    ) -> CloudItemMetadata:
+        written = 0
+        with open(local_tmp_path, "wb") as handle:
+            async for chunk in chunks:
+                written += len(chunk)
+                if written > size:
+                    raise CloudForbidden("upload body exceeds Content-Length")
+                handle.write(chunk)
+        if written != size:
+            raise CloudForbidden("upload body does not match Content-Length")
+        return await self.upload(path, local_tmp_path, overwrite=overwrite)
+
     async def move(self, source: str, destination: str, *, overwrite: bool = False) -> CloudItemMetadata:
         async with self._lock:
             src = self._to_local(source)
@@ -183,4 +203,3 @@ def _is_relative_to(path: Path, root: Path) -> bool:
         return True
     except ValueError:
         return False
-

--- a/src/o2gateway/o2/api.py
+++ b/src/o2gateway/o2/api.py
@@ -5,6 +5,7 @@ import json
 import logging
 import mimetypes
 import re
+import secrets
 import time
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -65,6 +66,78 @@ class O2Item:
     fingerprint: Optional[str] = None
     node: Optional[str] = None
     download_token: Optional[str] = None
+
+
+class _StreamingMultipart(httpx.AsyncByteStream):
+    def __init__(
+        self,
+        source: AsyncIterator[bytes],
+        spool_path: str,
+        size: int,
+        metadata: dict[str, Any],
+        file_name: str,
+        content_type: str,
+    ) -> None:
+        boundary = secrets.token_hex(16)
+        data = json.dumps({"data": metadata}, separators=(",", ":")).encode("utf-8")
+        disposition_name = _multipart_parameter(file_name)
+        self.prefix = (
+            "--%s\r\n"
+            "Content-Disposition: form-data; name=\"data\"\r\n"
+            "Content-Type: application/json\r\n\r\n" % boundary
+        ).encode("ascii") + data + (
+            "\r\n--%s\r\n"
+            "Content-Disposition: form-data; name=\"file\"; filename=\"%s\"\r\n"
+            "Content-Type: %s\r\n\r\n" % (boundary, disposition_name, content_type)
+        ).encode("utf-8")
+        self.suffix = ("\r\n--%s--\r\n" % boundary).encode("ascii")
+        self.headers = {
+            "Content-Type": "multipart/form-data; boundary=%s" % boundary,
+            "Content-Length": str(len(self.prefix) + size + len(self.suffix)),
+        }
+        self.source = source
+        self.spool_path = spool_path
+        self.size = size
+        self.written = 0
+        self.complete = False
+        self.started = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        if self.started:
+            raise RuntimeError("streaming multipart body cannot be replayed")
+        self.started = True
+        yield self.prefix
+        with open(self.spool_path, "wb") as handle:
+            async for chunk in self.source:
+                if not chunk:
+                    continue
+                self._count(chunk)
+                handle.write(chunk)
+                yield chunk
+        self._finish()
+        yield self.suffix
+
+    async def finish_spooling(self) -> None:
+        if self.complete:
+            return
+        mode = "ab" if self.started else "wb"
+        with open(self.spool_path, mode) as handle:
+            async for chunk in self.source:
+                if not chunk:
+                    continue
+                self._count(chunk)
+                handle.write(chunk)
+        self._finish()
+
+    def _count(self, chunk: bytes) -> None:
+        self.written += len(chunk)
+        if self.written > self.size:
+            raise CloudError("upload body exceeds Content-Length")
+
+    def _finish(self) -> None:
+        if self.written != self.size:
+            raise CloudError("upload body does not match Content-Length")
+        self.complete = True
 
 
 class O2CloudApiClient:
@@ -239,20 +312,7 @@ class O2CloudApiClient:
         """
         started = time.perf_counter()
         size = Path(local_path).stat().st_size
-        metadata: dict[str, Any] = {
-            "name": name,
-            "size": size,
-            "modificationdate": "",
-            "folderid": _o2_id(parent_folder_id),
-        }
-        if media_id is not None:
-            metadata["id"] = _o2_id(media_id)
-        content_type = mimetypes.guess_type(name)[0]
-        if content_type:
-            metadata["contenttype"] = content_type
-        query = {"action": "save"}
-        if size > 200 * 1024 * 1024:
-            query["acceptasynchronous"] = "true"
+        metadata, content_type, query = _upload_details(parent_folder_id, name, size, media_id)
         response: Optional[httpx.Response] = None
         for attempt in range(2):
             session = self._require_session()
@@ -273,6 +333,66 @@ class O2CloudApiClient:
             self._capture_response_session(response, session)
             break
         assert response is not None
+        return await self._upload_response_item(response, parent_folder_id, name, size, media_id, started)
+
+    async def upload_file_stream(
+        self,
+        parent_folder_id: str,
+        name: str,
+        chunks: AsyncIterator[bytes],
+        size: int,
+        spool_path: str,
+        *,
+        media_id: Optional[str] = None,
+    ) -> O2Item:
+        """Forward an incoming WebDAV body to the provider while spooling it.
+
+        The spool is retained by the caller for the recent-upload overlay and is
+        also replayable when authentication recovery requires another request.
+        """
+        started = time.perf_counter()
+        metadata, content_type, query = _upload_details(parent_folder_id, name, size, media_id)
+        session = self._require_session()
+        stream = _StreamingMultipart(
+            chunks,
+            spool_path,
+            size,
+            metadata,
+            name,
+            content_type or "application/octet-stream",
+        )
+        headers = self._session_headers(session)
+        headers.update(
+            {
+                "Accept": "*/*",
+                "X-Requested-With": "XMLHttpRequest",
+                "Connection": "keep-alive",
+                **stream.headers,
+            }
+        )
+        try:
+            response = await self.client.post(self._upload_url(query, session), headers=headers, content=stream)
+        finally:
+            # If the provider or transport stops consuming the body early, keep
+            # draining Windows into the spool so a safe file-backed retry exists.
+            await stream.finish_spooling()
+        if response.status_code in AUTH_REJECTION_STATUSES:
+            if await self._recover_session(response, session):
+                return await self.upload_file(parent_folder_id, name, spool_path, media_id=media_id)
+            self._mark_session_expired()
+            raise CloudSessionExpired("%s rejected upload session" % self.settings.provider_label())
+        self._capture_response_session(response, session)
+        return await self._upload_response_item(response, parent_folder_id, name, size, media_id, started)
+
+    async def _upload_response_item(
+        self,
+        response: httpx.Response,
+        parent_folder_id: str,
+        name: str,
+        size: int,
+        media_id: Optional[str],
+        started: float,
+    ) -> O2Item:
         logger.info(
             "o2 upload post completed",
             extra={
@@ -761,6 +881,44 @@ def to_cloud_metadata(item: O2Item, path: str) -> CloudItemMetadata:
         etag=etag,
         raw={"mediaKind": item.media_kind, "directUrl": item.direct_url, "node": item.node, "downloadToken": item.download_token},
     )
+
+
+def _upload_details(
+    parent_folder_id: str,
+    name: str,
+    size: int,
+    media_id: Optional[str],
+) -> tuple[dict[str, Any], Optional[str], dict[str, str]]:
+    metadata: dict[str, Any] = {
+        "name": name,
+        "size": size,
+        "modificationdate": "",
+        "folderid": _o2_id(parent_folder_id),
+    }
+    if media_id is not None:
+        metadata["id"] = _o2_id(media_id)
+    content_type = mimetypes.guess_type(name)[0]
+    if content_type:
+        metadata["contenttype"] = content_type
+    query = {"action": "save"}
+    if size > 200 * 1024 * 1024:
+        query["acceptasynchronous"] = "true"
+    return metadata, content_type, query
+
+
+def _multipart_parameter(value: str) -> str:
+    output = []
+    for character in value:
+        codepoint = ord(character)
+        if character == '"':
+            output.append("%22")
+        elif character == "\\":
+            output.append("\\\\")
+        elif codepoint < 32:
+            output.append("%%%02X" % codepoint)
+        else:
+            output.append(character)
+    return "".join(output)
 
 
 def _object(value: Any) -> dict[str, Any]:

--- a/src/o2gateway/o2/store.py
+++ b/src/o2gateway/o2/store.py
@@ -171,6 +171,43 @@ class O2CloudFileStore:
         await self.cache.put(entry.metadata)
         return entry.metadata
 
+    async def upload_stream(
+        self,
+        path: str,
+        chunks: AsyncIterator[bytes],
+        size: int,
+        local_tmp_path: str,
+        *,
+        overwrite: bool = True,
+    ) -> CloudItemMetadata:
+        normalized = normalize_cloud_path(path)
+        parent = await self._item_for_path(parent_path(normalized))
+        if parent is None or not parent.is_folder:
+            raise CloudNotFound(parent_path(normalized))
+        remote_target = await self._remote_target_id(normalized, overwrite)
+        if size == 0:
+            return self._store_pending_create(normalized, parent.id, remote_target)
+        try:
+            uploaded = await self.api.upload_file_stream(
+                parent.id,
+                basename(normalized),
+                chunks,
+                size,
+                local_tmp_path,
+                media_id=remote_target,
+            )
+        except CloudMediaNotValidated:
+            uploaded = await self._upload_with_validation_retry(
+                parent.id,
+                basename(normalized),
+                local_tmp_path,
+                remote_target,
+            )
+        entry = self._store_uploaded(normalized, uploaded, local_tmp_path, parent.id)
+        await self.cache.invalidate(parent_path(normalized), normalized)
+        await self.cache.put(entry.metadata)
+        return entry.metadata
+
     async def delete(self, path: str, *, soft_delete: bool = True) -> None:
         normalized = normalize_cloud_path(path)
         entry = self._entry(normalized)
@@ -329,7 +366,10 @@ class O2CloudFileStore:
         local_copy: Optional[str] = None
         if size <= self.settings.upload_recent_cache_max_file_mb * 1024 * 1024:
             target = self._spool_dir() / ("upload-%s.tmp" % uuid4().hex)
-            shutil.copyfile(local_tmp_path, target)
+            try:
+                os.link(local_tmp_path, target)
+            except OSError:
+                shutil.copyfile(local_tmp_path, target)
             local_copy = str(target)
         remote_id = None if uploaded.id.startswith("pending:") else uploaded.id
         item = replace(uploaded, name=basename(normalized), parent_id=parent_folder_id, size=size)

--- a/src/o2gateway/webdav/router.py
+++ b/src/o2gateway/webdav/router.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
-from typing import Callable
+from typing import AsyncIterator, Callable, Optional
 
 from fastapi import APIRouter, Request
 from fastapi.responses import Response, StreamingResponse
@@ -189,12 +189,40 @@ async def _put(settings: Settings, store: CloudFileStore, cloud_path: str, reque
             pass
         return Response(status_code=204)
     max_bytes = settings.upload_max_file_mb * 1024 * 1024
+    content_length = _request_content_length(request)
+    if content_length is not None and content_length > max_bytes:
+        raise CloudForbidden("upload exceeds configured limit")
     Path(settings.upload_spool_dir).mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(prefix="upload-", suffix=".tmp", dir=settings.upload_spool_dir)
-    written = 0
+    os.close(fd)
     try:
+        existed = await store.get_metadata(cloud_path)
+        stream_upload = getattr(store, "upload_stream", None)
+        if content_length is not None and content_length > 0 and callable(stream_upload):
+            upload_started = time.perf_counter()
+            item = await stream_upload(
+                cloud_path,
+                _limited_request_stream(request, max_bytes),
+                content_length,
+                tmp_path,
+                overwrite=True,
+            )
+            logger.info(
+                "webdav streaming upload completed",
+                extra={
+                    "operation_id": operation_id,
+                    "path": cloud_path,
+                    "bytesIn": content_length,
+                    "statusCode": 204 if existed else 201,
+                    "durationMs": round((time.perf_counter() - upload_started) * 1000, 2),
+                },
+            )
+            headers = {"ETag": item.etag} if item.etag else {}
+            return Response(status_code=204 if existed else 201, headers=headers)
+
+        written = 0
         read_started = time.perf_counter()
-        with os.fdopen(fd, "wb") as handle:
+        with open(tmp_path, "wb") as handle:
             async for chunk in request.stream():
                 written += len(chunk)
                 if written > max_bytes:
@@ -209,7 +237,6 @@ async def _put(settings: Settings, store: CloudFileStore, cloud_path: str, reque
                 "durationMs": round((time.perf_counter() - read_started) * 1000, 2),
             },
         )
-        existed = await store.get_metadata(cloud_path)
         upload_started = time.perf_counter()
         item = await store.upload(cloud_path, tmp_path, overwrite=True)
         logger.info(
@@ -229,6 +256,28 @@ async def _put(settings: Settings, store: CloudFileStore, cloud_path: str, reque
             os.unlink(tmp_path)
         except OSError:
             pass
+
+
+def _request_content_length(request: Request) -> Optional[int]:
+    value = request.headers.get("content-length")
+    if value is None:
+        return None
+    try:
+        size = int(value)
+    except ValueError as ex:
+        raise ValueError("invalid Content-Length") from ex
+    if size < 0:
+        raise ValueError("invalid Content-Length")
+    return size
+
+
+async def _limited_request_stream(request: Request, max_bytes: int) -> AsyncIterator[bytes]:
+    written = 0
+    async for chunk in request.stream():
+        written += len(chunk)
+        if written > max_bytes:
+            raise CloudForbidden("upload exceeds configured limit")
+        yield chunk
 
 
 async def _mkcol(store: CloudFileStore, cloud_path: str) -> Response:

--- a/tests/test_o2_overlay_store.py
+++ b/tests/test_o2_overlay_store.py
@@ -10,6 +10,7 @@ Movistar (Funambol sapi), medido empíricamente:
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 
 from o2gateway.o2.api import O2Item
@@ -31,6 +32,8 @@ class FakeMovistarApi:
         self.unvalidated: set[str] = set()
         self.upload_calls: list[dict] = []
         self.trash_calls: list[str] = []
+        self.stream_upload_calls: list[dict] = []
+        self.reject_next_stream = False
         self._sequence = 0
 
     def _next_id(self) -> str:
@@ -84,6 +87,32 @@ class FakeMovistarApi:
         self.unvalidated.add(item.id)
         return item
 
+    async def upload_file_stream(self, parent_folder_id, name, chunks, size, spool_path, *, media_id=None):
+        content = bytearray()
+        with open(spool_path, "wb") as handle:
+            async for chunk in chunks:
+                content.extend(chunk)
+                handle.write(chunk)
+        self.stream_upload_calls.append({"name": name, "media_id": media_id, "size": len(content)})
+        assert len(content) == size
+        if self.reject_next_stream:
+            self.reject_next_stream = False
+            raise CloudMediaNotValidated("MED-1017")
+        return self._save_upload(parent_folder_id, name, bytes(content), media_id)
+
+    def _save_upload(self, parent_folder_id, name, content, media_id):
+        if media_id is not None:
+            if media_id in self.unvalidated:
+                raise CloudMediaNotValidated("MED-1017")
+            assert media_id in self.files
+            item = O2Item(media_id, name, parent_folder_id, False, size=len(content))
+        else:
+            item = O2Item(self._next_id(), name, parent_folder_id, False, size=len(content))
+        self.files[item.id] = item
+        self.contents[item.id] = content
+        self.unvalidated.add(item.id)
+        return item
+
     async def download(self, item, byte_range=None):
         content = self.contents[item.id]
         if byte_range is not None:
@@ -129,6 +158,36 @@ async def build(tmp_path, **overrides):
     return api, store
 
 
+class MemoryCache:
+    def __init__(self) -> None:
+        self.items = {}
+
+    async def get(self, path):
+        return self.items.get(path)
+
+    async def put(self, item):
+        self.items[item.path] = item
+
+    async def put_negative(self, path):
+        self.items.pop(path, None)
+
+    async def invalidate(self, *paths):
+        for path in paths:
+            self.items.pop(path, None)
+
+
+def build_stream_store(tmp_path):
+    settings = Settings(
+        cache_dir=str(tmp_path / "cache"),
+        upload_recent_cache_max_file_mb=1,
+        upload_recent_cache_ttl_seconds=900,
+        upload_overwrite_retry_seconds=8.0,
+    )
+    api = FakeMovistarApi()
+    store = O2CloudFileStore(api, MemoryCache(), settings)  # type: ignore[arg-type]
+    return api, store
+
+
 async def drain(store):
     while store._background_tasks:
         await asyncio.gather(*list(store._background_tasks), return_exceptions=True)
@@ -166,6 +225,39 @@ async def test_finder_copy_sequence_placeholder_then_content(tmp_path):
     listed = await store.list("/")
     assert [(item.name, item.size) for item in listed] == [("informe.txt", 26)]
     assert store._overlay == {}
+
+
+async def test_stream_upload_forwards_once_and_keeps_overlay_with_hardlink(tmp_path):
+    api, store = build_stream_store(tmp_path)
+    spool = tmp_path / "incoming.tmp"
+
+    async def chunks():
+        yield b"streamed "
+        yield b"content"
+
+    metadata = await store.upload_stream("/fast.txt", chunks(), 16, str(spool))
+
+    assert metadata.size == 16
+    assert api.stream_upload_calls == [{"name": "fast.txt", "media_id": None, "size": 16}]
+    assert api.upload_calls == []
+    overlay_path = store._overlay["/fast.txt"].local_path
+    assert overlay_path is not None
+    assert os.stat(spool).st_ino == os.stat(overlay_path).st_ino
+
+
+async def test_stream_upload_replays_spool_after_media_validation_error(tmp_path):
+    api, store = build_stream_store(tmp_path)
+    api.reject_next_stream = True
+    spool = tmp_path / "retry.tmp"
+
+    async def chunks():
+        yield b"retry me"
+
+    metadata = await store.upload_stream("/retry.txt", chunks(), 8, str(spool))
+
+    assert metadata.size == 8
+    assert api.stream_upload_calls == [{"name": "retry.txt", "media_id": None, "size": 8}]
+    assert api.upload_calls == [{"name": "retry.txt", "media_id": None, "size": 8}]
 
 
 async def test_placeholder_delete_never_touches_remote(tmp_path):

--- a/tests/test_streaming_upload.py
+++ b/tests/test_streaming_upload.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from o2gateway.o2.api import O2CloudApiClient, _StreamingMultipart
+from o2gateway.o2.session import O2Session
+from o2gateway.settings import Settings
+
+
+async def test_streaming_multipart_tees_chunks_and_has_exact_content_length(tmp_path):
+    source_events: list[str] = []
+
+    async def source():
+        source_events.append("first")
+        yield b"hello "
+        source_events.append("second")
+        yield b"world"
+
+    spool = tmp_path / "upload.tmp"
+    stream = _StreamingMultipart(
+        source(),
+        str(spool),
+        11,
+        {"name": "hello.txt", "size": 11, "folderid": "root"},
+        "hello.txt",
+        "text/plain",
+    )
+
+    iterator = stream.__aiter__()
+    prefix = await anext(iterator)
+    first = await anext(iterator)
+
+    assert source_events == ["first"]
+    assert first == b"hello "
+    assert stream.written == 6
+
+    remainder = [chunk async for chunk in iterator]
+    body = prefix + first + b"".join(remainder)
+    assert source_events == ["first", "second"]
+    assert spool.read_bytes() == b"hello world"
+    assert len(body) == int(stream.headers["Content-Length"])
+    assert b'filename="hello.txt"' in body
+    assert json.dumps({"data": {"name": "hello.txt", "size": 11, "folderid": "root"}}, separators=(",", ":")).encode() in body
+
+
+async def test_streaming_multipart_can_finish_spool_after_early_stop(tmp_path):
+    async def source():
+        yield b"first"
+        yield b"second"
+
+    spool = tmp_path / "upload.tmp"
+    stream = _StreamingMultipart(source(), str(spool), 11, {}, "x.bin", "application/octet-stream")
+    iterator = stream.__aiter__()
+    await anext(iterator)  # multipart prefix
+    await anext(iterator)  # first file chunk
+    await iterator.aclose()
+
+    await stream.finish_spooling()
+
+    assert stream.complete
+    assert spool.read_bytes() == b"firstsecond"
+
+
+async def test_api_streams_multipart_to_provider_and_spools_body(tmp_path):
+    received: list[bytes] = []
+
+    async def provider(request: httpx.Request) -> httpx.Response:
+        received.append(await request.aread())
+        return httpx.Response(200, json={"data": {"id": "remote-1", "name": "photo.jpg", "size": 11}})
+
+    class SessionStore:
+        def read(self):
+            return O2Session(validation_key="validation-key")
+
+        def save(self, session):
+            pass
+
+    client = O2CloudApiClient(Settings(), SessionStore())  # type: ignore[arg-type]
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(provider))
+    spool = tmp_path / "api-upload.tmp"
+
+    async def source():
+        yield b"hello "
+        yield b"world"
+
+    try:
+        item = await client.upload_file_stream("root", "photo.jpg", source(), 11, str(spool))
+    finally:
+        await client.close()
+
+    assert item.id == "remote-1"
+    assert item.size == 11
+    assert spool.read_bytes() == b"hello world"
+    assert len(received) == 1
+    assert b"hello world" in received[0]
+    assert b'filename="photo.jpg"' in received[0]

--- a/tests/test_webdav_streaming.py
+++ b/tests/test_webdav_streaming.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from starlette.requests import Request
+
+from o2gateway.cloud.base import CloudItemMetadata
+from o2gateway.settings import Settings
+from o2gateway.webdav.router import _put
+
+
+class UploadStore:
+    def __init__(self) -> None:
+        self.streamed = bytearray()
+        self.stream_calls = 0
+        self.file_calls = 0
+
+    async def get_metadata(self, path):
+        return None
+
+    async def upload_stream(self, path, chunks, size, local_tmp_path, *, overwrite=True):
+        self.stream_calls += 1
+        with open(local_tmp_path, "wb") as handle:
+            async for chunk in chunks:
+                self.streamed.extend(chunk)
+                handle.write(chunk)
+        assert len(self.streamed) == size
+        return _metadata(path, size)
+
+    async def upload(self, path, local_tmp_path, *, overwrite=True):
+        self.file_calls += 1
+        with open(local_tmp_path, "rb") as handle:
+            content = handle.read()
+        return _metadata(path, len(content))
+
+
+async def test_put_uses_streaming_store_when_content_length_is_known(tmp_path):
+    store = UploadStore()
+    request = _request([b"hello ", b"world"], content_length=11)
+    settings = Settings(upload_spool_dir=str(tmp_path), upload_max_file_mb=1)
+
+    response = await _put(settings, store, "/hello.txt", request, "test-op")  # type: ignore[arg-type]
+
+    assert response.status_code == 201
+    assert store.stream_calls == 1
+    assert store.file_calls == 0
+    assert store.streamed == b"hello world"
+
+
+async def test_put_falls_back_to_file_upload_without_content_length(tmp_path):
+    store = UploadStore()
+    request = _request([b"chunked body"])
+    settings = Settings(upload_spool_dir=str(tmp_path), upload_max_file_mb=1)
+
+    response = await _put(settings, store, "/chunked.txt", request, "test-op")  # type: ignore[arg-type]
+
+    assert response.status_code == 201
+    assert store.stream_calls == 0
+    assert store.file_calls == 1
+
+
+def _request(parts: list[bytes], content_length: int | None = None) -> Request:
+    messages = [
+        {"type": "http.request", "body": part, "more_body": index < len(parts) - 1}
+        for index, part in enumerate(parts)
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    headers = [] if content_length is None else [(b"content-length", str(content_length).encode("ascii"))]
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "PUT",
+            "scheme": "http",
+            "path": "/dav/file",
+            "raw_path": b"/dav/file",
+            "query_string": b"",
+            "headers": headers,
+            "client": ("127.0.0.1", 1234),
+            "server": ("localhost", 80),
+        },
+        receive,
+    )
+
+
+def _metadata(path: str, size: int) -> CloudItemMetadata:
+    return CloudItemMetadata(id="id", name=path.rsplit("/", 1)[-1], type="file", path=path, size=size)


### PR DESCRIPTION
## What changed

- stream WebDAV request bodies with a known `Content-Length` directly into the O2/Movistar multipart upload
- tee incoming chunks into the recovery spool while the provider upload is in progress
- replay the completed spool only when session recovery or `MED-1017` requires a retry
- retain the existing file-backed path for chunked uploads and providers without streaming support
- replace the recent-upload cache copy with a hardlink when both paths share a filesystem

## Why

The gateway previously received the complete WebDAV `PUT` into a temporary file before starting the provider request. A client-to-gateway transfer and a gateway-to-provider transfer therefore ran sequentially, making upload latency approximately the sum of both stages.

## Impact

In the normal path, the gateway now forwards each incoming block to O2/Movistar while writing the local recovery spool at the same time. End-to-end latency approaches the slower transfer instead of adding both transfer times. The spool remains available for safe retries and for the recent-upload overlay.

## Validation

- `pytest tests/test_streaming_upload.py tests/test_webdav_streaming.py tests/test_o2_overlay_store.py::test_stream_upload_forwards_once_and_keeps_overlay_with_hardlink tests/test_o2_overlay_store.py::test_stream_upload_replays_spool_after_media_validation_error tests/test_simulated_store.py tests/test_paths.py tests/test_xml.py -q`
- 12 tests passed
- Python bytecode compilation and `git diff --check` passed
- live Movistar smoke test: a known-length WebDAV `PUT` returned `201`, logged `webdav streaming upload completed`, and cleanup returned `204`
