### PR TITLE
feat: automate GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+
+  categories:
+    - title: "🚀 New features"
+      labels:
+        - enhancement
+
+    - title: "🐛 Bug fixes"
+      labels:
+        - bug
+
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+
+    - title: "🧰 Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: garanda21/o2cloud_gateway_webdav
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  release:
+    name: Test, publish image and create release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag
+        id: release
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          if [[ "${tag}" == "${version}" || ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: ${tag}" >&2
+            exit 1
+          fi
+
+          commit="$(git rev-list -n 1 "${tag}")"
+          git fetch origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "${commit}" origin/main; then
+            echo "Release tag must point to a commit contained in main" >&2
+            exit 1
+          fi
+
+          if [[ "${version}" == *-* ]]; then
+            channel="development"
+            prerelease="true"
+          else
+            channel="latest"
+            prerelease="false"
+          fi
+
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
+          echo "channel=${channel}" >> "${GITHUB_OUTPUT}"
+          echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,login]"
+
+      - name: Run tests and source checks
+        run: |
+          python -m pytest -q
+          python -m compileall -q src tests
+          git diff --check
+
+      - name: Validate Docker Hub credentials
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
+            echo "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets are required" >&2
+            exit 1
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.3.0
+
+      - name: Build and push linux/amd64 image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.release.outputs.version }}
+            ${{ env.IMAGE_NAME }}:${{ steps.release.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:${{ steps.release.outputs.channel }}
+          build-args: |
+            APP_VERSION=${{ steps.release.outputs.version }}
+            GIT_COMMIT=${{ steps.release.outputs.commit }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          IS_PRERELEASE: ${{ steps.release.outputs.prerelease }}
+        shell: bash
+        run: |
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "GitHub release ${RELEASE_TAG} already exists; leaving it unchanged"
+            exit 0
+          fi
+
+          options=(
+            "${RELEASE_TAG}"
+            --verify-tag
+            --title "O2Cloud WebDAV Gateway ${RELEASE_VERSION}"
+            --generate-notes
+          )
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            options+=(--prerelease)
+          fi
+          gh release create "${options[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,13 @@ RUN python -m playwright install --with-deps chromium
 
 # Keep source revision metadata after the dependency layers so a new commit does
 # not invalidate the expensive OS, Python and Chromium installation cache.
+ARG APP_VERSION=0.1.0
 ARG GIT_COMMIT=unknown
-ENV APP_COMMIT=${GIT_COMMIT}
-LABEL org.opencontainers.image.revision=${GIT_COMMIT}
+ENV APP_VERSION=${APP_VERSION} \
+    APP_COMMIT=${GIT_COMMIT}
+LABEL org.opencontainers.image.source="https://github.com/garanda21/o2cloud_gateway_webdav" \
+      org.opencontainers.image.version=${APP_VERSION} \
+      org.opencontainers.image.revision=${GIT_COMMIT}
 
 COPY src /app/src
 COPY docker/entrypoint.sh docker/xdisplay.sh /app/docker/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # O2/Movistar Cloud WebDAV Gateway
 
 [![Docker Hub](https://img.shields.io/badge/Docker%20Hub-garanda21%2Fo2cloud__gateway__webdav-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/garanda21/o2cloud_gateway_webdav)
+[![GitHub Release](https://img.shields.io/github/v/release/garanda21/o2cloud_gateway_webdav?display_name=tag)](https://github.com/garanda21/o2cloud_gateway_webdav/releases)
 
 A Docker-first, Linux-native gateway that exposes **O2 Cloud** and **Movistar Cloud**
 (Telefónica personal cloud storage services) as a standard **WebDAV** share, plus a
@@ -35,6 +36,7 @@ caching behind the scenes.
 - [Environment variables](#environment-variables)
 - [Ports](#ports)
 - [Local development](#local-development)
+- [Releasing](#releasing)
 - [Project layout](#project-layout)
 
 ---
@@ -443,16 +445,59 @@ pytest
 uvicorn o2gateway.main:create_app --factory --reload
 ```
 
-To include the source commit in the admin footer when building the container:
+To include the release version and source commit in the admin footer when building
+the container:
 
 ```bash
-docker build --build-arg GIT_COMMIT="$(git rev-parse --short=8 HEAD)" -t o2cloud-webdav-gateway .
+docker build \
+  --build-arg APP_VERSION="0.1.0" \
+  --build-arg GIT_COMMIT="$(git rev-parse HEAD)" \
+  -t o2cloud-webdav-gateway .
 ```
 
 The package version is always shown; the commit is appended when available.
 
 The source targets Python **3.12+** and intentionally avoids newer syntax where
 practical, so local smoke tests can run on older macOS Python builds.
+
+## Releasing
+
+GitHub Releases and Docker Hub images are published together by
+`.github/workflows/release.yml`. The workflow runs only for version tags matching
+`v*.*.*`, verifies that the tagged commit belongs to `main`, runs the complete test
+suite, builds the image for `linux/amd64`, pushes it to Docker Hub and finally creates
+a GitHub Release with automatically generated notes.
+
+Configure these GitHub Actions repository secrets before publishing the first release:
+
+| Secret | Purpose |
+|--------|---------|
+| `DOCKERHUB_USERNAME` | Docker Hub account allowed to push `garanda21/o2cloud_gateway_webdav`. |
+| `DOCKERHUB_TOKEN` | Docker Hub access token with read/write permission. Do not use the account password. |
+
+Pull requests should be labelled `enhancement`, `bug` or `documentation` before
+merging. `.github/release.yml` uses those labels to organize the generated changelog;
+unlabelled changes appear under **Other changes**, and `ignore-for-release` excludes
+internal-only work.
+
+Stable releases publish version-specific tags plus `latest`:
+
+```bash
+git switch main
+git pull --ff-only
+git tag -a v0.1.0 -m "v0.1.0"
+git push origin v0.1.0
+```
+
+This publishes `0.1.0`, `v0.1.0` and `latest`. A prerelease tag such as
+`v0.2.0-rc.1` is marked as a GitHub prerelease and publishes `0.2.0-rc.1`,
+`v0.2.0-rc.1` and `development` without changing `latest`.
+
+The tag value is injected as `APP_VERSION`, while its full source revision is injected
+as `APP_COMMIT`; both link back to this repository from the admin panel. Review the
+generated release notes after publication, especially for the first release, because
+commits made directly on `main` appear in the full comparison but not necessarily as
+individual pull-request entries.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary

- categorize automatically generated GitHub release notes using pull request labels
- validate version tags and require release commits to belong to main
- run the full test suite before publishing
- build and push linux/amd64 images to Docker Hub
- publish stable tags as the version, the v-prefixed version, and latest
- publish prereleases as the version, the v-prefixed version, and development
- inject the release version and source commit into the image and admin UI
- document the required Docker Hub secrets and release procedure

## Validation

- 33 tests passed
- actionlint passed
- YAML parsing, Python compilation, and diff checks passed
- local linux/amd64 Docker build completed successfully
- image architecture and OCI labels verified
- container smoke test passed for /health
- OpenAPI exposed the injected release version

## Before the first release

Configure the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets before pushing v0.1.0.